### PR TITLE
Increased Touch Sensitivity

### DIFF
--- a/src/js/addons/jquery.tosrus.drag.js
+++ b/src/js/addons/jquery.tosrus.drag.js
@@ -124,7 +124,7 @@
 								else
 								{
 									var slideWidth = that.nodes.$slides.first().width(),
-										slides = Math.floor( ( Math.abs( _distance ) + ( slideWidth / 2 ) ) / slideWidth );	
+										slides = Math.floor( ( Math.abs( _distance ) + ( slideWidth * .95 ) ) / slideWidth );	
 								}
 		
 								if ( slides > 0 )


### PR DESCRIPTION
on mobile, it requires the user to swipe half the screen before next/prev swipe is initiated . Instead of slideWidth/2 I changed it to slideWidth*.95 - now only 5% is required to trigger next slide on swipe.
